### PR TITLE
Removed request for parameter 'shots' in statevector simulators

### DIFF
--- a/qiskit_addon_sympy/statevector_simulator_sympy.py
+++ b/qiskit_addon_sympy/statevector_simulator_sympy.py
@@ -188,10 +188,8 @@ class StatevectorSimulatorSympy(BaseBackend):
                         }]
         """
         qobj = q_job.qobj
+        self._validate(qobj)
         result_list = []
-        shots = qobj['config']['shots']
-        if shots > 1:
-            logger.info("No need for multiple shots. A single execution will be performed.")
         for circuit in qobj['circuits']:
             result_list.append(self.run_circuit(circuit))
         return Result({'job_id': q_job.job_id, 'result': result_list,
@@ -334,3 +332,31 @@ class StatevectorSimulatorSympy(BaseBackend):
                 return CGate(qid_tuple[0], ugate)
         # if the control flow comes here,  alarm!
         raise Exception('Not supported')
+
+    # TODO: Remove duplication between files in statevector_simulator_*.py:
+    #       methods _validate and _set_shots_to_1
+    def _validate(self, qobj):
+        """Semantic validations of the qobj which cannot be done via schemas.
+        Some of these may later move to backend schemas.
+
+        1. No shots
+        2. No measurements in the middle
+        """
+        self._set_shots_to_1(qobj, False)
+        for circuit in qobj['circuits']:
+            self._set_shots_to_1(circuit, True)
+            for operator in circuit['compiled_circuit']['operations']:
+                if operator['name'] in ['measure', 'reset']:
+                    raise SimulatorError("In circuit {}: statevector simulator does "
+                                         "not support measure or reset.".format(circuit['name']))
+
+    def _set_shots_to_1(self, dictionary, include_name):
+        if 'config' not in dictionary:
+            dictionary['config'] = {}
+        if 'shots' in dictionary['config'] and dictionary['config']['shots'] != 1:
+            warn = 'statevector simulator only supports 1 shot. Setting shots=1'
+            if include_name:
+                warn += 'Setting shots=1 for circuit' + dictionary['name']
+            warn += '.'
+            logger.warning(warn)
+        dictionary['config']['shots'] = 1

--- a/test_sympy/test_statevector_simulator_sympy.py
+++ b/test_sympy/test_statevector_simulator_sympy.py
@@ -47,8 +47,7 @@ class StatevectorSimulatorSympyTest(QiskitTestCase):
         self.qobj = {'id': 'test_sim_single_shot',
                      'config': {
                          'max_credits': resources['max_credits'],
-                         'shots': 1024,
-                         'backend_name': 'local_statevector_simulator_sympy',
+                         'backend_name': 'local_statevector_simulator_sympy'
                      },
                      'circuits': [
                          {
@@ -65,7 +64,7 @@ class StatevectorSimulatorSympyTest(QiskitTestCase):
                                 preformatted=True)
 
     def test_statevector_simulator_sympy(self):
-        """Test data counts output for single circuit run against reference."""
+        """Test final state vector for single circuit run."""
         result = StatevectorSimulatorSympy().run(self.q_job).result()
         actual = result.get_data('test')['statevector']
         self.assertEqual(result.get_status(), 'COMPLETED')


### PR DESCRIPTION
This is related to https://github.com/QISKit/qiskit-core/pull/436.
Note that this does not resolve https://github.com/QISKit/qiskit-addon-sympy/issues/11#issuecomment-397417985.