### PR TITLE
Removed dependence on cloned qiskit-core

### DIFF
--- a/Make.bat
+++ b/Make.bat
@@ -24,12 +24,12 @@ ECHO.
 GOTO :end
 
 :lint
-pylint -rn qiskit_addon_sympy test_sympy
+pylint -rn qiskit_addon_sympy test
 IF errorlevel 9009 GOTO :error
 GOTO :next
 
 :test
-python -m unittest discover -s test_sympy -v
+python -m unittest discover -v
 IF errorlevel 9009 GOTO :error
 GOTO :next
 

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,15 @@
 
 # Ignoring generated ones with .py extension.
 lint:
-	pylint -rn qiskit_addon_sympy test_sympy
+	pylint -rn qiskit_addon_sympy test
 
 style:
-	pycodestyle --max-line-length=100 qiskit_addon_sympy test_sympy
+	pycodestyle --max-line-length=100 qiskit_addon_sympy test
 
 # Use the -s (starting directory) flag for "unittest discover" is necessary,
 # otherwise the QuantumCircuit header will be modified during the discovery.
 test:
-	python3 -m unittest discover -s test_sympy -v
+	python3 -m unittest discover -v
 
 profile:
 	python3 -m unittest discover -p "profile*.py" -v

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""QISKit Sympy simulators unit tests."""
+
+import os
+
+
+def load_tests(loader, standard_tests, pattern):
+    """
+    test suite for unittest discovery
+    """
+    this_dir = os.path.dirname(__file__)
+    if pattern in ['test*.py', '*_test.py']:
+        package_tests = loader.discover(start_dir=this_dir, pattern=pattern)
+        standard_tests.addTests(package_tests)
+    elif pattern in ['profile*.py', '*_profile.py']:
+        loader.testMethodPrefix = 'profile'
+        package_tests = loader.discover(start_dir=this_dir, pattern='test*.py')
+        standard_tests.addTests(package_tests)
+    return standard_tests

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,7 +5,11 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""QISKit Sympy simulators unit tests."""
+"""
+QISKit Sympy simulators unit tests.
+Note: see Issue #4 - this file is temporary;
+      common.py in qiskit-core will move to a location which is included in the pip package.
+"""
 
 import os
 

--- a/test/common.py
+++ b/test/common.py
@@ -5,7 +5,11 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Shared functionality and helpers for the unit tests."""
+"""
+Shared functionality and helpers for the unit tests.
+Note: see Issue #4 - this file is temporary;
+      common.py in qiskit-core will move to a location which is included in the pip package.
+"""
 
 from enum import Enum
 import functools

--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,288 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Shared functionality and helpers for the unit tests."""
+
+from enum import Enum
+import functools
+import inspect
+import logging
+import os
+import unittest
+from unittest.util import safe_repr
+from qiskit_addon_sympy import __path__ as main_path
+
+
+class Path(Enum):
+    """Helper with paths commonly used during the tests."""
+    # Main path:    qiskit-addon-sympy
+    MAIN = main_path[0]
+    # test path: qiskit-addon-sympy/test
+    TEST = os.path.dirname(__file__)
+    # Examples path:    examples/
+    EXAMPLES = os.path.join(MAIN, '../examples')
+
+
+class QiskitSympyTestCase(unittest.TestCase):
+    """Helper class that contains common functionality."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.moduleName = os.path.splitext(inspect.getfile(cls))[0]
+        cls.log = logging.getLogger(cls.__name__)
+
+        # Set logging to file and stdout if the LOG_LEVEL environment variable
+        # is set.
+        if os.getenv('LOG_LEVEL'):
+            # Set up formatter.
+            log_fmt = ('{}.%(funcName)s:%(levelname)s:%(asctime)s:'
+                       ' %(message)s'.format(cls.__name__))
+            formatter = logging.Formatter(log_fmt)
+
+            # Set up the file handler.
+            log_file_name = '%s.log' % cls.moduleName
+            file_handler = logging.FileHandler(log_file_name)
+            file_handler.setFormatter(formatter)
+            cls.log.addHandler(file_handler)
+
+            # Set the logging level from the environment variable, defaulting
+            # to INFO if it is not a valid level.
+            level = logging._nameToLevel.get(os.getenv('LOG_LEVEL'),
+                                             logging.INFO)
+            cls.log.setLevel(level)
+
+    @staticmethod
+    def _get_resource_path(filename, path=Path.TEST):
+        """ Get the absolute path to a resource.
+
+        Args:
+            filename (string): filename or relative path to the resource.
+            path (Path): path used as relative to the filename.
+        Returns:
+            str: the absolute path to the resource.
+        """
+        return os.path.normpath(os.path.join(path.value, filename))
+
+    def assertNoLogs(self, logger=None, level=None):
+        """
+        Context manager to test that no message is sent to the specified
+        logger and level (the opposite of TestCase.assertLogs()).
+        """
+        # pylint: disable=invalid-name
+        return _AssertNoLogsContext(self, logger, level)
+
+    def assertDictAlmostEqual(self, dict1, dict2, delta=None, msg=None,
+                              places=None, default_value=0):
+        """
+        Assert two dictionaries with numeric values are almost equal.
+
+        Fail if the two dictionaries are unequal as determined by
+        comparing that the difference between values with the same key are
+        not greater than delta (default 1e-8), or that difference rounded
+        to the given number of decimal places is not zero. If a key in one
+        dictionary is not in the other the default_value keyword argument
+        will be used for the missing value (default 0). If the two objects
+        compare equal then they will automatically compare almost equal.
+
+        Args:
+            dict1 (dict): a dictionary.
+            dict2 (dict): a dictionary.
+            delta (number): threshold for comparison (defaults to 1e-8).
+            msg (str): return a custom message on failure.
+            places (int): number of decimal places for comparison.
+            default_value (number): default value for missing keys.
+
+        Raises:
+            TypeError: raises TestCase failureException if the test fails.
+        """
+        # pylint: disable=invalid-name
+        if dict1 == dict2:
+            # Shortcut
+            return
+        if delta is not None and places is not None:
+            raise TypeError("specify delta or places not both")
+
+        if places is not None:
+            success = True
+            standard_msg = ''
+            # check value for keys in target
+            keys1 = set(dict1.keys())
+            for key in keys1:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if round(abs(val1 - val2), places) != 0:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            # check values for keys in counts, not in target
+            keys2 = set(dict2.keys()) - keys1
+            for key in keys2:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if round(abs(val1 - val2), places) != 0:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            if success is True:
+                return
+            standard_msg = standard_msg[:-2] + ' within %s places' % places
+
+        else:
+            if delta is None:
+                delta = 1e-8  # default delta value
+            success = True
+            standard_msg = ''
+            # check value for keys in target
+            keys1 = set(dict1.keys())
+            for key in keys1:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if abs(val1 - val2) > delta:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            # check values for keys in counts, not in target
+            keys2 = set(dict2.keys()) - keys1
+            for key in keys2:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if abs(val1 - val2) > delta:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            if success is True:
+                return
+            standard_msg = standard_msg[:-2] + ' within %s delta' % delta
+
+        msg = self._formatMessage(msg, standard_msg)
+        raise self.failureException(msg)
+
+
+class _AssertNoLogsContext(unittest.case._AssertLogsContext):
+    """A context manager used to implement TestCase.assertNoLogs()."""
+
+    # pylint: disable=inconsistent-return-statements
+    def __exit__(self, exc_type, exc_value, tb):
+        """
+        This is a modified version of TestCase._AssertLogsContext.__exit__(...)
+        """
+        self.logger.handlers = self.old_handlers
+        self.logger.propagate = self.old_propagate
+        self.logger.setLevel(self.old_level)
+        if exc_type is not None:
+            # let unexpected exceptions pass through
+            return False
+
+        if self.watcher.records:
+            msg = 'logs of level {} or higher triggered on {}:\n'.format(
+                logging.getLevelName(self.level), self.logger.name)
+            for record in self.watcher.records:
+                msg += 'logger %s %s:%i: %s\n' % (record.name, record.pathname,
+                                                  record.lineno,
+                                                  record.getMessage())
+
+            self._raiseFailure(msg)
+
+
+def slow_test(func):
+    """
+    Decorator that signals that the test takes minutes to run.
+
+    Args:
+        func (callable): test function to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+
+    @functools.wraps(func)
+    def _(*args, **kwargs):
+        if SKIP_SLOW_TESTS:
+            raise unittest.SkipTest('Skipping slow tests')
+        return func(*args, **kwargs)
+
+    return _
+
+
+def requires_qe_access(func):
+    """
+    Decorator that signals that the test uses the online API:
+        * determines if the test should be skipped by checking environment
+            variables.
+        * if the test is not skipped, it reads `QE_TOKEN` and `QE_URL` from
+            `Qconfig.py` or from environment variables.
+        * if the test is not skipped, it appends `QE_TOKEN` and `QE_URL` as
+            arguments to the test function.
+    Args:
+        func (callable): test function to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+
+    @functools.wraps(func)
+    def _(*args, **kwargs):
+        # pylint: disable=invalid-name
+        if SKIP_ONLINE_TESTS:
+            raise unittest.SkipTest('Skipping online tests')
+
+        # Try to read the variables from Qconfig.
+        try:
+            import Qconfig
+            QE_TOKEN = Qconfig.APItoken
+            QE_URL = Qconfig.config['url']
+            QE_HUB = Qconfig.config.get('hub')
+            QE_GROUP = Qconfig.config.get('group')
+            QE_PROJECT = Qconfig.config.get('project')
+        except ImportError:
+            # Try to read them from environment variables (ie. Travis).
+            QE_TOKEN = os.getenv('QE_TOKEN')
+            QE_URL = os.getenv('QE_URL')
+            QE_HUB = os.getenv('QE_HUB')
+            QE_GROUP = os.getenv('QE_GROUP')
+            QE_PROJECT = os.getenv('QE_PROJECT')
+        if not QE_TOKEN or not QE_URL:
+            raise Exception(
+                'Could not locate a valid "Qconfig.py" file nor read the QE '
+                'values from the environment')
+
+        kwargs['QE_TOKEN'] = QE_TOKEN
+        kwargs['QE_URL'] = QE_URL
+        kwargs['hub'] = QE_HUB
+        kwargs['group'] = QE_GROUP
+        kwargs['project'] = QE_PROJECT
+        return func(*args, **kwargs)
+
+    return _
+
+
+def _is_ci_fork_pull_request():
+    """
+    Check if the tests are being run in a CI environment and if it is a pull
+    request.
+
+    Returns:
+        bool: True if the tests are executed inside a CI tool, and the changes
+            are not against the "master" branch.
+    """
+    if os.getenv('TRAVIS'):
+        # Using Travis CI.
+        if os.getenv('TRAVIS_PULL_REQUEST_BRANCH'):
+            return True
+    elif os.getenv('APPVEYOR'):
+        # Using AppVeyor CI.
+        if os.getenv('APPVEYOR_PULL_REQUEST_NUMBER'):
+            return True
+    return False
+
+
+SKIP_ONLINE_TESTS = os.getenv('SKIP_ONLINE_TESTS', _is_ci_fork_pull_request())
+SKIP_SLOW_TESTS = os.getenv('SKIP_SLOW_TESTS', True) not in ['false', 'False', '-1']

--- a/test/simple.qasm
+++ b/test/simple.qasm
@@ -1,0 +1,6 @@
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+
+h q[0];
+cx q[0],q[1];

--- a/test/test_statevector_simulator_sympy.py
+++ b/test/test_statevector_simulator_sympy.py
@@ -7,7 +7,7 @@
 
 # pylint: disable=invalid-name,missing-docstring
 
-from test.python.common import QiskitTestCase
+from test.common import QiskitSympyTestCase
 
 import unittest
 
@@ -15,41 +15,28 @@ from sympy import sqrt
 
 from qiskit import (load_qasm_file, execute, QuantumRegister,
                     ClassicalRegister, QuantumCircuit, wrapper)
-from qiskit_addon_sympy import UnitarySimulatorSympy
+from qiskit_addon_sympy import StatevectorSimulatorSympy
 
 
-class UnitarySimulatorSympyTest(QiskitTestCase):
-    """Test local unitary simulator sympy."""
+class StatevectorSimulatorSympyTest(QiskitSympyTestCase):
+    """Test local statevector simulator."""
 
     def setUp(self):
-        self.qasm_filename = self._get_resource_path('qasm/simple.qasm')
+        self.qasm_filename = self._get_resource_path('simple.qasm')
         self.q_circuit = load_qasm_file(self.qasm_filename)
 
-    def test_unitary_simulator(self):
-        """test generation of circuit unitary"""
-
-        result = execute(self.q_circuit, backend=UnitarySimulatorSympy()).result()
-        actual = result.get_unitary(self.q_circuit)
-
-        self.assertEqual(actual[0][0], sqrt(2)/2)
-        self.assertEqual(actual[0][1], sqrt(2)/2)
-        self.assertEqual(actual[0][2], 0)
-        self.assertEqual(actual[0][3], 0)
-        self.assertEqual(actual[1][0], 0)
-        self.assertEqual(actual[1][1], 0)
-        self.assertEqual(actual[1][2], sqrt(2)/2)
-        self.assertEqual(actual[1][3], -sqrt(2)/2)
-        self.assertEqual(actual[2][0], 0)
-        self.assertEqual(actual[2][1], 0)
-        self.assertEqual(actual[2][2], sqrt(2)/2)
-        self.assertEqual(actual[2][3], sqrt(2)/2)
-        self.assertEqual(actual[3][0], sqrt(2)/2)
-        self.assertEqual(actual[3][1], -sqrt(2)/2)
-        self.assertEqual(actual[3][2], 0)
-        self.assertEqual(actual[3][3], 0)
+    def test_statevector_simulator_sympy(self):
+        """Test final state vector for single circuit run."""
+        result = execute(self.q_circuit, backend=StatevectorSimulatorSympy()).result()
+        actual = result.get_statevector(self.q_circuit)
+        self.assertEqual(result.get_status(), 'COMPLETED')
+        self.assertEqual(actual[0], sqrt(2)/2)
+        self.assertEqual(actual[1], 0)
+        self.assertEqual(actual[2], 0)
+        self.assertEqual(actual[3], sqrt(2)/2)
 
 
-class TestQobj(QiskitTestCase):
+class TestQobj(QiskitSympyTestCase):
     """Check the objects compiled for this backend create names properly"""
 
     def setUp(self):
@@ -63,7 +50,7 @@ class TestQobj(QiskitTestCase):
         self.circuits = [qc]
 
     def test_qobj_statevector_simulator_sympy(self):
-        qobj = wrapper.compile(self.circuits, backend=UnitarySimulatorSympy())
+        qobj = wrapper.compile(self.circuits, backend=StatevectorSimulatorSympy())
         cc = qobj['circuits'][0]['compiled_circuit']
         ccq = qobj['circuits'][0]['compiled_circuit_qasm']
         self.assertIn(self.qr_name, map(lambda x: x[0], cc['header']['qubit_labels']))

--- a/test/test_unitary_simulator_sympy.py
+++ b/test/test_unitary_simulator_sympy.py
@@ -7,7 +7,7 @@
 
 # pylint: disable=invalid-name,missing-docstring
 
-from test.python.common import QiskitTestCase
+from test.common import QiskitSympyTestCase
 
 import unittest
 
@@ -15,28 +15,41 @@ from sympy import sqrt
 
 from qiskit import (load_qasm_file, execute, QuantumRegister,
                     ClassicalRegister, QuantumCircuit, wrapper)
-from qiskit_addon_sympy import StatevectorSimulatorSympy
+from qiskit_addon_sympy import UnitarySimulatorSympy
 
 
-class StatevectorSimulatorSympyTest(QiskitTestCase):
-    """Test local statevector simulator."""
+class UnitarySimulatorSympyTest(QiskitSympyTestCase):
+    """Test local unitary simulator sympy."""
 
     def setUp(self):
-        self.qasm_filename = self._get_resource_path('qasm/simple.qasm')
+        self.qasm_filename = self._get_resource_path('simple.qasm')
         self.q_circuit = load_qasm_file(self.qasm_filename)
 
-    def test_statevector_simulator_sympy(self):
-        """Test final state vector for single circuit run."""
-        result = execute(self.q_circuit, backend=StatevectorSimulatorSympy()).result()
-        actual = result.get_statevector(self.q_circuit)
-        self.assertEqual(result.get_status(), 'COMPLETED')
-        self.assertEqual(actual[0], sqrt(2)/2)
-        self.assertEqual(actual[1], 0)
-        self.assertEqual(actual[2], 0)
-        self.assertEqual(actual[3], sqrt(2)/2)
+    def test_unitary_simulator(self):
+        """test generation of circuit unitary"""
+
+        result = execute(self.q_circuit, backend=UnitarySimulatorSympy()).result()
+        actual = result.get_unitary(self.q_circuit)
+
+        self.assertEqual(actual[0][0], sqrt(2)/2)
+        self.assertEqual(actual[0][1], sqrt(2)/2)
+        self.assertEqual(actual[0][2], 0)
+        self.assertEqual(actual[0][3], 0)
+        self.assertEqual(actual[1][0], 0)
+        self.assertEqual(actual[1][1], 0)
+        self.assertEqual(actual[1][2], sqrt(2)/2)
+        self.assertEqual(actual[1][3], -sqrt(2)/2)
+        self.assertEqual(actual[2][0], 0)
+        self.assertEqual(actual[2][1], 0)
+        self.assertEqual(actual[2][2], sqrt(2)/2)
+        self.assertEqual(actual[2][3], sqrt(2)/2)
+        self.assertEqual(actual[3][0], sqrt(2)/2)
+        self.assertEqual(actual[3][1], -sqrt(2)/2)
+        self.assertEqual(actual[3][2], 0)
+        self.assertEqual(actual[3][3], 0)
 
 
-class TestQobj(QiskitTestCase):
+class TestQobj(QiskitSympyTestCase):
     """Check the objects compiled for this backend create names properly"""
 
     def setUp(self):
@@ -50,7 +63,7 @@ class TestQobj(QiskitTestCase):
         self.circuits = [qc]
 
     def test_qobj_statevector_simulator_sympy(self):
-        qobj = wrapper.compile(self.circuits, backend=StatevectorSimulatorSympy())
+        qobj = wrapper.compile(self.circuits, backend=UnitarySimulatorSympy())
         cc = qobj['circuits'][0]['compiled_circuit']
         ccq = qobj['circuits'][0]['compiled_circuit_qasm']
         self.assertIn(self.qr_name, map(lambda x: x[0], cc['header']['qubit_labels']))


### PR DESCRIPTION
Following discussion in Issue #4.
- Copied and adjusted qiskit/test/python/common.py and qiskit/test/python/__init__.py to qiskit_addon_sympy/test.
- Adjusted Sympy tests.

As a result:
- Tests can be executed with pip installed qiskit-core.
- Travis automatic checks for pull requests of this repository will stop failing (because they use pip installed qiskit-core).