### PR TITLE
Use logger.info when setting shots to 1 in the statevector simulator.

### DIFF
--- a/qiskit_addon_sympy/statevector_simulator_sympy.py
+++ b/qiskit_addon_sympy/statevector_simulator_sympy.py
@@ -350,5 +350,5 @@ class StatevectorSimulatorSympy(BaseBackend):
             if include_name:
                 warn += 'Setting shots=1 for circuit' + dictionary['name']
             warn += '.'
-            logger.warning(warn)
+            logger.info(warn)
         dictionary['config']['shots'] = 1


### PR DESCRIPTION
In pull request #13 we modified code around warnings invoked by the statevector simulator when the number of shots is different from 1. These warnings had been conveyed to the user by logger.info, and should have been remained that way. By mistake, one of them became logger.warn. This pull requests takes it back to logger.info.